### PR TITLE
vdf-server-2 failed to launch due to a jiffy.so linker error

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -46,7 +46,7 @@ endif
 CFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 CXXFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -ldl -lpthread -lei
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -ldl -lpthread -lei -lstdc++
 
 # Verbosity.
 


### PR DESCRIPTION
adding -lstdc++ fixed it... but not sure why only vdf-server-2 has a problem