### PR TITLE
Preserve shared linking flags on Linux.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -38,9 +38,11 @@ else ifeq ($(UNAME_SYS), FreeBSD)
 	CXXFLAGS ?= -O3 -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -fPIC -O3 -std=c99 -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -fPIC -O3 -Wall
-	LDFLAGS ?= -shared
+	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+	CFLAGS += -fPIC
+	CXXFLAGS += -fPIC
+	LDFLAGS += -shared
 endif
 
 CFLAGS += -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)


### PR DESCRIPTION
If the user has CFLAGS, CXXFLAGS or LDFLAGS set in their environment, then the ?= conditional assignments lose the -fPIC and -shared flags, resulting in build failure.

This change preserves these crucial flags while also including the user's environment settings.